### PR TITLE
Fix rotation

### DIFF
--- a/Assets/Prefabs/Puzzle/Puzzle1.prefab
+++ b/Assets/Prefabs/Puzzle/Puzzle1.prefab
@@ -89,10 +89,34 @@ MonoBehaviour:
       m_Calls: []
   m_SelectEntered:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1291013243612644886}
+        m_TargetAssemblyTypeName: PuzzleSystem, Assembly-CSharp
+        m_MethodName: DisableGrabbableChildren
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_SelectExited:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1291013243612644886}
+        m_TargetAssemblyTypeName: PuzzleSystem, Assembly-CSharp
+        m_MethodName: EnableGrabbableChildren
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_Activated:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/PuzzleSystem.cs
+++ b/Assets/Scripts/PuzzleSystem.cs
@@ -12,16 +12,18 @@ public class PuzzleSystem : MonoBehaviour
 
     public LaserEvent checker;
 
-        
+    private XRRestrictedMovement[] grabbableChildren;
+
+
     void Awake()
     {
-        
+        grabbableChildren = GetComponentsInChildren<XRRestrictedMovement>();
     }
 
     // Update is called once per frame
     void Update()
     {
-           
+
     }
 
     private void OnEnable()
@@ -46,7 +48,23 @@ public class PuzzleSystem : MonoBehaviour
     {
 
         return checkList.TrueForAll(element => element.isOnLaser);
-        
 
+
+    }
+
+    public void EnableGrabbableChildren()
+    {
+        foreach (var child in grabbableChildren)
+        {
+            child.enabled = true;
+        }
+    }
+
+    public void DisableGrabbableChildren()
+    {
+        foreach (var child in grabbableChildren)
+        {
+            child.enabled = false;
+        }
     }
 }

--- a/Assets/Scripts/XRRestrictedMovement.cs
+++ b/Assets/Scripts/XRRestrictedMovement.cs
@@ -107,8 +107,7 @@ public class XRRestrictedMovement : XRBaseInteractable
                     // 1. Get rotation of rigidbody (Quaternion)
                     Quaternion rigidBodyRotation = m_Rb.rotation;
                     // We want local x axis too.
-
-                    Vector3 xAxisOfThis = transform.right;
+                    Vector3 xAxisOfThis = Vector3.right;
                     
 
                     // Previous position of hand when first grabbed : m_GrabbedPosition
@@ -117,18 +116,19 @@ public class XRRestrictedMovement : XRBaseInteractable
                     // Subtract.
                     Vector3 oldCenterToController = m_GrabbedPosition - transform.position;
                     oldCenterToController.Normalize();
-                    Vector3 centeroToController = currentInteractorPosition - transform.position;
-                    centeroToController.Normalize();
+                    Vector3 newCenterToController = currentInteractorPosition - transform.position;
+                    newCenterToController.Normalize();
 
                     // 2. Calculate angle between two vectors.
 
                     // Calculate signed angle between two vectors, with local x axis as axis.
-                    float relativeInteractorAngle = Vector3.SignedAngle(oldCenterToController, centeroToController, xAxisOfThis);
+                    float relativeInteractorAngle = Vector3.SignedAngle(oldCenterToController, newCenterToController, xAxisOfThis);
                     if (relativeInteractorAngle < 0) relativeInteractorAngle = 360 + relativeInteractorAngle;
+                    //Debug.Log($"angle: {relativeInteractorAngle}");
 
                     // 3. reconstruct rotation from angle and x axis used.
                     Quaternion requiredRotation = Quaternion.AngleAxis(relativeInteractorAngle, xAxisOfThis);
-                    
+                    //Debug.Log(requiredRotation.eulerAngles);
 
                     // 4. generate rotation.
                     m_Rb.MoveRotation(rigidBodyRotation * requiredRotation);


### PR DESCRIPTION
This pull request fixes:
- borked rotation when puzzle is even slightly moved or rotated
- "splitting" problem, where puzzle could be disintegrated by grabbing puzzle parent and slot: grabbing slot is disabled while grabbing parent puzzle.